### PR TITLE
Update lodash to older version 4.17.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1401,6 +1401,12 @@
                         "ms": "^2.1.1"
                     }
                 },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
                 "semver": {
                     "version": "7.3.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -2755,6 +2761,12 @@
                 "yargs": "^13.3.0"
             },
             "dependencies": {
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
                 "supports-color": {
                     "version": "6.1.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -5860,6 +5872,12 @@
                     "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                     "dev": true
                 },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
                 "string-width": {
                     "version": "4.2.0",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -6407,9 +6425,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+            "version": "4.17.14",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+            "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
         },
         "lodash.camelcase": {
             "version": "4.3.0",
@@ -15402,6 +15420,12 @@
                 "ws": "^6.0.0"
             },
             "dependencies": {
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
                 "ws": {
                     "version": "6.2.1",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -15759,6 +15783,14 @@
                 "flat": "^4.1.0",
                 "lodash": "^4.17.15",
                 "yargs": "^13.3.0"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "@nteract/transform-vega": "^6.0.3",
         "@nteract/transforms": "^4.4.4",
         "@phosphor/widgets": "^1.9.3",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.14",
         "react": "^16.8.4",
         "react-dom": "^16.8.4",
         "uuid": "^3.3.2"


### PR DESCRIPTION
4.17.15 has a known security vulnerability, hence using 4.17.14
