### PR TITLE
Update output directories of the builds

### DIFF
--- a/build/webpack/webpack.client.config.js
+++ b/build/webpack/webpack.client.config.js
@@ -16,7 +16,7 @@ module.exports = {
         renderers: './src/client/index.tsx'
     },
     output: {
-        path: path.join(constants.ExtensionRootDir, 'out', 'client'),
+        path: path.join(constants.ExtensionRootDir, 'out', 'client_renderer'),
         filename: '[name].js',
         chunkFilename: `[name].bundle.js`
     },

--- a/build/webpack/webpack.extension.config.js
+++ b/build/webpack/webpack.extension.config.js
@@ -14,7 +14,7 @@ module.exports = {
     },
     output: {
         filename: 'index.js',
-        path: path.resolve(constants.ExtensionRootDir, 'out', 'extension'),
+        path: path.resolve(constants.ExtensionRootDir, 'out', 'extension_renderer'),
         libraryTarget: 'commonjs2',
         devtoolModuleFilenameTemplate: '../../[resource-path]'
     },

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "activationEvents": [
         "*"
     ],
-    "main": "./out/extension/index.js",
+    "main": "./out/extension_renderer/index.js",
     "contributes": {
         "notebookOutputRenderer": [
             {
                 "id": "jupyter-notebook-renderer",
-                "entrypoint": "./out/client/renderers.js",
+                "entrypoint": "./out/client_renderer/renderers.js",
                 "displayName": "Jupyter Notebook Renderer",
                 "mimeTypes": [
                     "application/geo+json",

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 
 export function activate(context: ExtensionContext): { rendererPath: string } {
     return {
-        rendererPath: path.join(context.extensionPath, 'out', 'client', 'renderers.js')
+        rendererPath: path.join(context.extensionPath, 'out', 'client_renderer', 'renderers.js')
     };
 }
 

--- a/src/extension/tsconfig.json
+++ b/src/extension/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../tsconfig-base.json",
     "compilerOptions": {
         "rootDir": ".",
-        "outDir": "../../out/extension",
+        "outDir": "../../out/extension_renderer",
         "lib": [
             "ES2019",
             "dom"


### PR DESCRIPTION
* Plan is to build and upload VSIX to blob store or the like
* When we build (locally or CI) Jupyter extension download this VSIX, unzip and copy files from output into jupyter extension 
* This way jupyter extsnion will work during dev & build (download assets just as we do with the C++ exe for cryptography)

https://github.com/microsoft/vscode-jupyter/issues/4149
https://github.com/microsoft/vscode-jupyter/issues/3936