### PR TITLE
Fix plotly under ES6 import

### DIFF
--- a/build/webpack/webpack.client.config.js
+++ b/build/webpack/webpack.client.config.js
@@ -135,6 +135,9 @@ module.exports = {
                 test: /plotly\.js$/,
                 use: [
                     {
+                        // https://github.com/plotly/plotly.js/issues/3518#issuecomment-779758848
+                        // Plotly bundle doesn't work under ES6 import. Using the work around (minified version)
+                        // from the link above
                         loader: StringReplacePlugin.replace({
                             replacements: [
                                 {

--- a/build/webpack/webpack.client.config.js
+++ b/build/webpack/webpack.client.config.js
@@ -7,6 +7,7 @@ const constants = require('../constants');
 const configFileName = 'src/client/tsconfig.json';
 const { DefinePlugin } = require('webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const StringReplacePlugin = require('string-replace-webpack-plugin');
 // Any build on the CI is considered production mode.
 const isProdBuild = constants.isCI || process.argv.some((argv) => argv.includes('mode') && argv.includes('production'));
 
@@ -36,6 +37,7 @@ module.exports = {
         new DefinePlugin({
             scriptUrl: 'import.meta.url'
         }),
+        new StringReplacePlugin(),
         ...common.getDefaultPlugins('extension')
     ],
     stats: {
@@ -126,6 +128,23 @@ module.exports = {
                 use: [
                     {
                         loader: 'node-loader'
+                    }
+                ]
+            },
+            {
+                test: /plotly\.js$/,
+                use: [
+                    {
+                        loader: StringReplacePlugin.replace({
+                            replacements: [
+                                {
+                                    pattern: /module.exports = d3; else this.d3 = d3;\n}\(\);/,
+                                    replacement: function () {
+                                        return 'module.exports = d3; else this.d3 = d3;\n}.apply(self);';
+                                    }
+                                }
+                            ]
+                        })
                     }
                 ]
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
                 "node-loader": "^2.0.0",
                 "npm": "^6.14.5",
                 "prettier": "^2.0.5",
+                "string-replace-webpack-plugin": "^0.1.3",
                 "style-loader": "^1.2.1",
                 "svg-inline-loader": "^0.8.2",
                 "thread-loader": "^2.1.3",
@@ -2004,6 +2005,16 @@
                 "ajv": "^6.9.1"
             }
         },
+        "node_modules/amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.2"
+            }
+        },
         "node_modules/anser": {
             "version": "1.4.9",
             "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.9.tgz",
@@ -2404,6 +2415,12 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/async": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+            "dev": true
         },
         "node_modules/async-done": {
             "version": "1.3.2",
@@ -3775,6 +3792,19 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/csso": {
+            "version": "1.3.12",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-1.3.12.tgz",
+            "integrity": "sha1-/GKGlKLTiTiqrEmWdTIY/TEc254=",
+            "dev": true,
+            "optional": true,
+            "bin": {
+                "csso": "bin/csso"
+            },
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/csstype": {
@@ -5454,6 +5484,49 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/file-loader": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
+            "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "loader-utils": "~0.2.5"
+            }
+        },
+        "node_modules/file-loader/node_modules/big.js": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/file-loader/node_modules/json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true,
+            "optional": true,
+            "bin": {
+                "json5": "lib/cli.js"
+            }
+        },
+        "node_modules/file-loader/node_modules/loader-utils": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0",
+                "object-assign": "^4.0.1"
             }
         },
         "node_modules/file-uri-to-path": {
@@ -16256,6 +16329,89 @@
             "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
             "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
         },
+        "node_modules/string-replace-webpack-plugin": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/string-replace-webpack-plugin/-/string-replace-webpack-plugin-0.1.3.tgz",
+            "integrity": "sha1-c8ZX51nWbP6Arh4M8JGqJW0OcVw=",
+            "dev": true,
+            "dependencies": {
+                "async": "~0.2.10",
+                "loader-utils": "~0.2.3"
+            },
+            "optionalDependencies": {
+                "css-loader": "^0.9.1",
+                "file-loader": "^0.8.1",
+                "style-loader": "^0.8.3"
+            },
+            "peerDependencies": {
+                "webpack": "^1.4.2 || >=2.2.0"
+            }
+        },
+        "node_modules/string-replace-webpack-plugin/node_modules/big.js": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/string-replace-webpack-plugin/node_modules/css-loader": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.9.1.tgz",
+            "integrity": "sha1-LhqgDOfjDvLGp6SzAKCAp8l54Nw=",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "csso": "1.3.x",
+                "loader-utils": "~0.2.2",
+                "source-map": "~0.1.38"
+            }
+        },
+        "node_modules/string-replace-webpack-plugin/node_modules/json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true,
+            "bin": {
+                "json5": "lib/cli.js"
+            }
+        },
+        "node_modules/string-replace-webpack-plugin/node_modules/loader-utils": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0",
+                "object-assign": "^4.0.1"
+            }
+        },
+        "node_modules/string-replace-webpack-plugin/node_modules/source-map": {
+            "version": "0.1.43",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+            "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "amdefine": ">=0.0.4"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/string-replace-webpack-plugin/node_modules/style-loader": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.8.3.tgz",
+            "integrity": "sha1-9Pkut9tjdodI8VBlzWcA9aHIU1c=",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "loader-utils": "^0.2.5"
+            }
+        },
         "node_modules/string-width": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -19960,6 +20116,13 @@
             "dev": true,
             "requires": {}
         },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true,
+            "optional": true
+        },
         "anser": {
             "version": "1.4.9",
             "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.9.tgz",
@@ -20279,6 +20442,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "async": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
             "dev": true
         },
         "async-done": {
@@ -21450,6 +21619,13 @@
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true
+        },
+        "csso": {
+            "version": "1.3.12",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-1.3.12.tgz",
+            "integrity": "sha1-/GKGlKLTiTiqrEmWdTIY/TEc254=",
+            "dev": true,
+            "optional": true
         },
         "csstype": {
             "version": "2.6.9",
@@ -22895,6 +23071,45 @@
             "dev": true,
             "requires": {
                 "flat-cache": "^2.0.1"
+            }
+        },
+        "file-loader": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
+            "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "loader-utils": "~0.2.5"
+            },
+            "dependencies": {
+                "big.js": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+                    "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+                    "dev": true,
+                    "optional": true
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+                    "dev": true,
+                    "optional": true
+                },
+                "loader-utils": {
+                    "version": "0.2.17",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
+                    }
+                }
             }
         },
         "file-uri-to-path": {
@@ -32085,6 +32300,77 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
             "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
+        },
+        "string-replace-webpack-plugin": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/string-replace-webpack-plugin/-/string-replace-webpack-plugin-0.1.3.tgz",
+            "integrity": "sha1-c8ZX51nWbP6Arh4M8JGqJW0OcVw=",
+            "dev": true,
+            "requires": {
+                "async": "~0.2.10",
+                "css-loader": "^0.9.1",
+                "file-loader": "^0.8.1",
+                "loader-utils": "~0.2.3",
+                "style-loader": "^0.8.3"
+            },
+            "dependencies": {
+                "big.js": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+                    "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+                    "dev": true
+                },
+                "css-loader": {
+                    "version": "0.9.1",
+                    "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.9.1.tgz",
+                    "integrity": "sha1-LhqgDOfjDvLGp6SzAKCAp8l54Nw=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "csso": "1.3.x",
+                        "loader-utils": "~0.2.2",
+                        "source-map": "~0.1.38"
+                    }
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+                    "dev": true
+                },
+                "loader-utils": {
+                    "version": "0.2.17",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
+                    }
+                },
+                "source-map": {
+                    "version": "0.1.43",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                },
+                "style-loader": {
+                    "version": "0.8.3",
+                    "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.8.3.tgz",
+                    "integrity": "sha1-9Pkut9tjdodI8VBlzWcA9aHIU1c=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "loader-utils": "^0.2.5"
+                    }
+                }
+            }
         },
         "string-width": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
         "node-loader": "^2.0.0",
         "npm": "^6.14.5",
         "prettier": "^2.0.5",
+        "string-replace-webpack-plugin": "^0.1.3",
         "style-loader": "^1.2.1",
         "svg-inline-loader": "^0.8.2",
         "thread-loader": "^2.1.3",


### PR DESCRIPTION
https://github.com/microsoft/vscode-jupyter/issues/5967
Moving renderers to ES6 import breaks plotly bundle. Using a workaround to string replace and fix up a minified bundle.

Workaround / issue discussion here:
https://github.com/plotly/plotly.js/issues/3518

Tested by building release of extension and copying client_renderer into the jupyter extension out directory. 
![image](https://user-images.githubusercontent.com/812783/119857405-60b2cf80-bec8-11eb-8aa7-c930a88439bb.png)
