### PR TITLE
Bump plotly.js to v2.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12347,9 +12347,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-2.2.1.tgz",
-            "integrity": "sha512-xgsho2rx/XhrkqqqhycnsY0uBJa6R1YO+uEph4DgJpW8p/JLQZgBWQKtmc8Q6QXhoysQthjvTmP97H4PFTYSww=="
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-2.6.3.tgz",
+            "integrity": "sha512-qApdpFKV8HVrPCJJxfK+2D0jCGcJfDE0IqiSoeG7nmxLATvVVVn2OThmt5vNDnOeJOHf/yUzZ46rxelBJ2/30g=="
         },
         "polygon-offset": {
             "version": "0.3.1",
@@ -13024,7 +13024,7 @@
                 "parse-entities": "^1.1.0",
                 "repeat-string": "^1.5.4",
                 "state-toggle": "^1.0.0",
-                "trim": "0.0.3",
+                "trim": "0.0.1",
                 "trim-trailing-lines": "^1.0.0",
                 "unherit": "^1.0.4",
                 "unist-util-remove-position": "^1.0.0",
@@ -13033,7 +13033,7 @@
             },
             "dependencies": {
                 "trim": {
-                    "version": "0.0.3",
+                    "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
                     "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
                 }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
         "@phosphor/widgets": "^1.9.3",
         "lodash": "^4.17.21",
         "path-browserify": "^0.0.1",
-        "plotly.js-dist": "^2.2.0",
+        "plotly.js-dist": "^2.6.3",
         "re-resizable": "~6.5.5",
         "react": "^16.8.4",
         "react-dom": "^16.8.4",


### PR DESCRIPTION
We used to bump `plotly.js` in `vscode-jupyter` e.g. https://github.com/microsoft/vscode-jupyter/pull/6552.
But now this repository appears to be the right place.

cc: @rchiodo @IanMatthewHuff @nicolaskruchten 