### PR TITLE
outputId from the new metadata.id

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -44,7 +44,7 @@ function renderOutput(outputItem: OutputItem, element: HTMLElement, ctx: Rendere
         console.log(`Rendering mimeType ${mimeString}`, output);
 
         ReactDOM.render(
-            React.createElement(CellOutput, { mimeType: mimeString, output, ctx, outputId: outputItem.id }, null),
+            React.createElement(CellOutput, { mimeType: mimeString, output, ctx, outputId: (outputItem.metadata as any)?.id || outputItem.id }, null),
             element
         );
     } catch (ex) {


### PR DESCRIPTION
The idea of this PR is to set the `outputId` based on the output's `metadata.id`. This is because `output.id` is being deprecated. For more information: https://github.com/microsoft/vscode-jupyter/issues/9629