### PR TITLE
Ensure outputs generated using `IPython.display.code` are displayed with the right syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixes to rendering of Vega 5, VegaLite 3 and VegaLite 4.
 * Fixes to rendering of JavaScript mime types to ensure the right variables are available and right context is setup.
 * Ensure `jQuery` is available when rendering JavaScript mime types.
+* Ensure outputs generated using `IPython.display.code` are displayed with the right syntax highlighting.
 
 ## 1.0.7
 * Update plotly to version 2.11.1

--- a/build/webpack/webpack.client.config.js
+++ b/build/webpack/webpack.client.config.js
@@ -14,7 +14,7 @@ module.exports = {
     context: constants.ExtensionRootDir,
     entry: {
         renderers: './src/client/index.tsx',
-        javascriptRenderer: './src/client/javascriptRenderer.ts',
+        builtinRendererHooks: './src/client/builtinRendererHooks.ts',
         vegaRenderer: './src/client/vegaRenderer.ts'
     },
     output: {

--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
                 ]
             },
             {
-                "id": "jupyter-notebook-js-renderer",
-                "displayName": "Jupyter Notebook JS Renderer",
+                "id": "jupyter-notebook-built-in-renderer-hooks",
+                "displayName": "Jupyter Notebook Html/JavaScript Renderer",
                 "requiresMessaging": "optional",
                 "entrypoint": {
                     "extends": "vscode.builtin-renderer",
-                    "path": "./out/client_renderer/javascriptRenderer.js"
+                    "path": "./out/client_renderer/builtinRendererHooks.js"
                 }
             },
             {

--- a/src/client/builtinRendererHooks.ts
+++ b/src/client/builtinRendererHooks.ts
@@ -24,13 +24,21 @@ if (!('$' in globalThis) && !('jQuery' in globalThis)) {
 }
 export async function activate(ctx: RendererContext<void>) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const jsRenderer = await ctx.getRenderer('vscode.builtin-renderer');
-    if (!jsRenderer) {
+    const builtinRenderer = await ctx.getRenderer('vscode.builtin-renderer');
+    if (!builtinRenderer) {
         throw new Error('Could not find the built-in js renderer');
     }
     try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (jsRenderer.experimental_registerJavaScriptRenderingHook as any)({
+        (builtinRenderer.experimental_registerHtmlRenderingHook as any)({
+            async postRender(_outputItem: OutputItem, element: HTMLElement, _signal: AbortSignal): Promise<undefined> {
+                // Output container is expected to have the class `output_html`
+                element.classList.add('output_html');
+                return;
+            }
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (builtinRenderer.experimental_registerJavaScriptRenderingHook as any)({
             async preEvaluate(
                 outputItem: OutputItem,
                 element: HTMLElement,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/11402