### PR TITLE
Expose require, define and $ in globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+* Update version number to 1.1.0.
+
 ## 1.0.11
 * Ship jQuery and requirejs as pre-load scripts so that all outputs have access to these scripts.
 

--- a/build/webpack/postBuildHook.js
+++ b/build/webpack/postBuildHook.js
@@ -18,12 +18,10 @@ class PostBuildHookWebpackPlugin {
                     throw new Error('Unable to update require.js');
                 }
                 // Ensure jQuery, require and define are globally available.
-                const declarations = [
-                    'globalThis.require = require;',
-                    'globalThis.define = define;',
-                    'globalThis.$ = $;'
-                ];
-                requireFileContents = `${requireFileContents.replace(undefDeclaration, fixedUndefDeclaration)}\n\n`;
+                const declarations = ['globalThis.$ = $;'];
+                requireFileContents = `${requireFileContents
+                    .replace(invocationDeclaration, fixedInvocationDeclaration)
+                    .replace(undefDeclaration, fixedUndefDeclaration)}\n\n`;
                 const newContents = `${requireFileContents}\n\n\n${fs.readFileSync(jqueryFile).toString()}\n\n\n${fs
                     .readFileSync(file)
                     .toString()}\n\n\n${declarations.join('\n')}`;
@@ -33,6 +31,8 @@ class PostBuildHookWebpackPlugin {
     }
 }
 
+const invocationDeclaration = `}(this, (typeof setTimeout === 'undefined' ? undefined : setTimeout)));`;
+const fixedInvocationDeclaration = `}(globalThis, (typeof setTimeout === 'undefined' ? undefined : setTimeout)));`;
 const undefDeclaration = `                    localRequire.undef = function (id) {
                         //Bind any waiting define() calls to this context,
                         //fix for #408

--- a/build/webpack/postBuildHook.js
+++ b/build/webpack/postBuildHook.js
@@ -13,13 +13,101 @@ class PostBuildHookWebpackPlugin {
                 }
                 const requireFile = path.join(__dirname, '..', '..', 'node_modules', 'requirejs', 'require.js');
                 const jqueryFile = path.join(__dirname, '..', '..', 'node_modules', 'jquery', 'dist', 'jquery.min.js');
-                const newContents = `${fs.readFileSync(requireFile).toString()}\n\n\n${fs
-                    .readFileSync(jqueryFile)
-                    .toString()}\n\n\n${fs.readFileSync(file).toString()}`;
+                let requireFileContents = fs.readFileSync(requireFile).toString();
+                if (!requireFileContents.includes(undefDeclaration)) {
+                    throw new Error('Unable to update require.js');
+                }
+                // Ensure jQuery, require and define are globally available.
+                const declarations = [
+                    'globalThis.require = require;',
+                    'globalThis.define = define;',
+                    'globalThis.$ = $;'
+                ];
+                requireFileContents = `${requireFileContents.replace(undefDeclaration, fixedUndefDeclaration)}\n\n`;
+                const newContents = `${requireFileContents}\n\n\n${fs.readFileSync(jqueryFile).toString()}\n\n\n${fs
+                    .readFileSync(file)
+                    .toString()}\n\n\n${declarations.join('\n')}`;
                 fs.writeFileSync(file, newContents);
             }
         });
     }
 }
+
+const undefDeclaration = `                    localRequire.undef = function (id) {
+                        //Bind any waiting define() calls to this context,
+                        //fix for #408
+                        takeGlobalQueue();
+
+                        var map = makeModuleMap(id, relMap, true),
+                            mod = getOwn(registry, id);
+
+                        mod.undefed = true;
+                        removeScript(id);
+
+                        delete defined[id];
+                        delete urlFetched[map.url];
+                        delete undefEvents[id];
+
+                        //Clean queued defines too. Go backwards
+                        //in array so that the splices do not
+                        //mess up the iteration.
+                        eachReverse(defQueue, function(args, i) {
+                            if (args[0] === id) {
+                                defQueue.splice(i, 1);
+                            }
+                        });
+                        delete context.defQueueMap[id];
+
+                        if (mod) {
+                            //Hold on to listeners in case the
+                            //module will be attempted to be reloaded
+                            //using a different config.
+                            if (mod.events.defined) {
+                                undefEvents[id] = mod.events;
+                            }
+
+                            cleanRegistry(id);
+                        }
+                    };`;
+const fixedUndefDeclaration = `                    localRequire.undef = function (id) {
+                        try {
+                        //Bind any waiting define() calls to this context,
+                        //fix for #408
+                        takeGlobalQueue();
+
+                        var map = makeModuleMap(id, relMap, true),
+                            mod = getOwn(registry, id);
+
+                        mod.undefed = true;
+                        removeScript(id);
+
+                        delete defined[id];
+                        delete urlFetched[map.url];
+                        delete undefEvents[id];
+
+                        //Clean queued defines too. Go backwards
+                        //in array so that the splices do not
+                        //mess up the iteration.
+                        eachReverse(defQueue, function(args, i) {
+                            if (args[0] === id) {
+                                defQueue.splice(i, 1);
+                            }
+                        });
+                        delete context.defQueueMap[id];
+
+                        if (mod) {
+                            //Hold on to listeners in case the
+                            //module will be attempted to be reloaded
+                            //using a different config.
+                            if (mod.events.defined) {
+                                undefEvents[id] = mod.events;
+                            }
+
+                            cleanRegistry(id);
+                        }
+                        } catch (e) {
+                          console.error('require.undef in Notebook Renderer failed', id, e);
+                        }
+                    };`;
 
 module.exports = PostBuildHookWebpackPlugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "jupyter-renderers",
-    "version": "1.0.11",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "jupyter-renderers",
-            "version": "1.0.11",
+            "version": "1.1.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "jupyter-renderers",
     "displayName": "Jupyter Notebook Renderers",
     "description": "Renderers for Jupyter Notebooks (with plotly, vega, gif, png, svg, jpeg and other such outputs)",
-    "version": "1.0.12",
+    "version": "1.1.0",
     "engines": {
         "vscode": "^1.73.0-insider"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "jupyter-renderers",
     "displayName": "Jupyter Notebook Renderers",
     "description": "Renderers for Jupyter Notebooks (with plotly, vega, gif, png, svg, jpeg and other such outputs)",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "engines": {
         "vscode": "^1.73.0-insider"
     },


### PR DESCRIPTION
Forgot to expose the jQuery and require functions as globals.
In Jupyter the require.undef errors are ignored, we need to do the same. here.