### PR TITLE
Update Version to 1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 1.1.0
-* Update version number to 1.1.0.
-
 ## 1.0.11
 * Ship jQuery and requirejs as pre-load scripts so that all outputs have access to these scripts.
 

--- a/build/webpack/postBuildHook.js
+++ b/build/webpack/postBuildHook.js
@@ -18,7 +18,11 @@ class PostBuildHookWebpackPlugin {
                     throw new Error('Unable to update require.js');
                 }
                 // Ensure jQuery, require and define are globally available.
-                const declarations = ['globalThis.$ = $;'];
+                const declarations = [
+                    'globalThis.$ = $;',
+                    'window.$ = $;',
+                    'window.require=window.requirejs=requirejs; window.define=define;'
+                ];
                 requireFileContents = `${requireFileContents
                     .replace(invocationDeclaration, fixedInvocationDeclaration)
                     .replace(undefDeclaration, fixedUndefDeclaration)}\n\n`;
@@ -106,7 +110,7 @@ const fixedUndefDeclaration = `                    localRequire.undef = function
                             cleanRegistry(id);
                         }
                         } catch (e) {
-                          console.error('require.undef in Notebook Renderer failed', id, e);
+                          console.warn('require.undef in Notebook Renderer failed', id, e);
                         }
                     };`;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "jupyter-renderers",
-    "version": "1.1.0",
+    "version": "1.0.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "jupyter-renderers",
-            "version": "1.1.0",
+            "version": "1.0.11",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "jupyter-renderers",
     "displayName": "Jupyter Notebook Renderers",
     "description": "Renderers for Jupyter Notebooks (with plotly, vega, gif, png, svg, jpeg and other such outputs)",
-    "version": "1.1.0",
+    "version": "1.0.11",
     "engines": {
         "vscode": "^1.73.0-insider"
     },


### PR DESCRIPTION
Thought 1.0.11 wasn't released because of a version issue, however found that the new pipelines requrie approval for publishing this extension.
Hence reverting the version back.

Fixes https://github.com/microsoft/vscode-jupyter/issues/6404