### PR TITLE
Update version to 1.0.12

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,6 +5,7 @@ build/**
 out/test/**
 src/**
 .gitignore
+.nvmrc
 node_modules
 vsc-extension-quickstart.md
 **/tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.11
+## 1.0.12
 * Ship jQuery and requirejs as pre-load scripts so that all outputs have access to these scripts.
 
 ## 1.0.10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "jupyter-renderers",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "jupyter-renderers",
-            "version": "1.0.11",
+            "version": "1.0.12",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "jupyter-renderers",
     "displayName": "Jupyter Notebook Renderers",
     "description": "Renderers for Jupyter Notebooks (with plotly, vega, gif, png, svg, jpeg and other such outputs)",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "engines": {
         "vscode": "^1.73.0-insider"
     },


### PR DESCRIPTION
Some how it seems  1.0.11 is in the marketplace
Publishing a new version to fix this 
https://github.com/microsoft/vscode-jupyter/issues/6404

Trying version 1.0.12

@rebornix @rzhao271 /cc
![Screen Shot 2022-10-27 at 12 15 44](https://user-images.githubusercontent.com/1948812/198168800-e854983c-892e-4bc9-b418-af62d7c67ef6.png)
![Screen Shot 2022-10-27 at 12 15 55](https://user-images.githubusercontent.com/1948812/198168809-8289aafc-6650-4162-bd9c-ed1d773ce325.png)
