### PR TITLE
Add styles for jupyter markdown alerts

### DIFF
--- a/build/webpack/webpack.client.config.js
+++ b/build/webpack/webpack.client.config.js
@@ -15,6 +15,7 @@ const defaultConfig = {
     context: constants.ExtensionRootDir,
     entry: {
         renderers: './src/client/index.tsx',
+        markdown: './src/client/markdown.ts',
         builtinRendererHooks: './src/client/builtinRendererHooks.ts',
         vegaRenderer: './src/client/vegaRenderer.ts'
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
                 "@types/glob": "^7.1.1",
                 "@types/loadable__component": "^5.10.0",
                 "@types/lodash": "^4.14.158",
+                "@types/markdown-it": "^12.2.3",
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^12.11.7",
                 "@types/react": "^16.9.35",
@@ -1931,6 +1932,12 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
         },
+        "node_modules/@types/linkify-it": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+            "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+            "dev": true
+        },
         "node_modules/@types/loadable__component": {
             "version": "5.13.4",
             "resolved": "https://registry.npmjs.org/@types/loadable__component/-/loadable__component-5.13.4.tgz",
@@ -1944,6 +1951,22 @@
             "version": "4.14.182",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
             "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+        },
+        "node_modules/@types/markdown-it": {
+            "version": "12.2.3",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+            "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/linkify-it": "*",
+                "@types/mdurl": "*"
+            }
+        },
+        "node_modules/@types/mdurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+            "dev": true
         },
         "node_modules/@types/minimatch": {
             "version": "3.0.5",
@@ -13935,6 +13958,12 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
         },
+        "@types/linkify-it": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+            "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+            "dev": true
+        },
         "@types/loadable__component": {
             "version": "5.13.4",
             "resolved": "https://registry.npmjs.org/@types/loadable__component/-/loadable__component-5.13.4.tgz",
@@ -13948,6 +13977,22 @@
             "version": "4.14.182",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
             "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+        },
+        "@types/markdown-it": {
+            "version": "12.2.3",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+            "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+            "dev": true,
+            "requires": {
+                "@types/linkify-it": "*",
+                "@types/mdurl": "*"
+            }
+        },
+        "@types/mdurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+            "dev": true
         },
         "@types/minimatch": {
             "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,18 @@
                     "application/vnd.vegalite.v4+json",
                     "application/vnd.vegalite.v5+json"
                 ]
+            },
+            {
+                "id": "jupyter-markdown",
+                "displayName": "Jupyter Markdown styles",
+                "entrypoint": {
+                    "extends": "vscode.markdown-it-renderer",
+                    "path": "./out/client_renderer/markdown.js"
+                }
             }
+        ],
+        "markdown.previewStyles": [
+            "resources/jupyter-markdown.css"
         ]
     },
     "scripts": {
@@ -170,6 +181,7 @@
         "@types/glob": "^7.1.1",
         "@types/loadable__component": "^5.10.0",
         "@types/lodash": "^4.14.158",
+        "@types/markdown-it": "^12.2.3",
         "@types/mocha": "^7.0.2",
         "@types/node": "^12.11.7",
         "@types/react": "^16.9.35",

--- a/resources/jupyter-markdown.css
+++ b/resources/jupyter-markdown.css
@@ -1,0 +1,37 @@
+/*
+Found that the colors of the alert boxes do not change with different themes in jlab.
+Hence hardcoded them here.
+*/
+
+.alert {
+    width: auto;
+    padding: 1em;
+    margin-top: 1em;
+    margin-bottom: 1em;
+	border-style: solid;
+	border-width: 1px;
+}
+.alert > *:last-child {
+    margin-bottom: 0;
+}
+#preview > .alert:last-child {
+    /* Prevent this being set to zero by the default notebook stylesheet */
+    padding-bottom: 1em;
+}
+
+.alert-success {
+    background-color: rgb(200,230,201);
+    color: rgb(27,94,32);
+}
+.alert-info {
+    background-color: rgb(178,235,242);
+    color: rgb(0,96,100);
+}
+.alert-warning {
+    background-color: rgb(255,224,178);
+    color: rgb(230,81,0);
+}
+.alert-danger {
+    background-color: rgb(255,205,210);
+    color: rgb(183,28,28);
+}

--- a/src/client/markdown.ts
+++ b/src/client/markdown.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as MarkdownIt from 'markdown-it';
+import type { RendererContext } from 'vscode-notebook-renderer';
+
+interface MarkdownItRenderer {
+    extendMarkdownIt(fn: (md: MarkdownIt) => void): void;
+}
+const css = `
+<style>
+/*
+Found that the colors of the alert boxes do not change with different themes in jlab.
+Hence hardcoded them here.
+*/
+
+.alert {
+    width: auto;
+    padding: 1em;
+    margin-top: 1em;
+    margin-bottom: 1em;
+	border-style: solid;
+	border-width: 1px;
+}
+.alert > *:last-child {
+    margin-bottom: 0;
+}
+#preview > .alert:last-child {
+    /* Prevent this being set to zero by the default notebook stylesheet */
+    padding-bottom: 1em;
+}
+
+.alert-success {
+    background-color: rgb(200,230,201);
+    color: rgb(27,94,32);
+}
+.alert-info {
+    background-color: rgb(178,235,242);
+    color: rgb(0,96,100);
+}
+.alert-warning {
+    background-color: rgb(255,224,178);
+    color: rgb(230,81,0);
+}
+.alert-danger {
+    background-color: rgb(255,205,210);
+    color: rgb(183,28,28);
+}
+</style>
+`;
+
+export async function activate(ctx: RendererContext<void>) {
+    const markdownItRenderer = (await ctx.getRenderer('vscode.markdown-it-renderer')) as MarkdownItRenderer | undefined;
+    if (!markdownItRenderer) {
+        throw new Error(`Could not load 'vscode.markdown-it-renderer'`);
+    }
+
+    markdownItRenderer.extendMarkdownIt((md: MarkdownIt) => {
+        const original = md.render.bind(md);
+        md.render = (src: string) => `${css}${original(src)}`;
+    });
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/10422

Now works in Notebooks as well as markdown.

![Screenshot 2022-12-30 at 11 28 54](https://user-images.githubusercontent.com/1948812/210023532-4b05f87c-c553-4cb2-804a-a3b762d6561e.png)
![Screenshot 2022-12-30 at 11 29 06](https://user-images.githubusercontent.com/1948812/210023535-15d55742-46aa-4363-9728-32bfe93862e0.png)
![Screenshot 2022-12-30 at 11 30 02](https://user-images.githubusercontent.com/1948812/210023577-f2164fc9-56f6-4d0c-bf56-12ab7db1bb07.png)
