### PR TITLE
Exclude ansi-to-react from output

### DIFF
--- a/build/webpack/webpack.client.config.js
+++ b/build/webpack/webpack.client.config.js
@@ -71,6 +71,8 @@ const defaultConfig = {
     },
     mode: isProdBuild ? 'production' : 'development',
     devtool: isProdBuild ? 'source-map' : 'inline-source-map',
+    // Exclude ansi-to-react to avoid warnings about CG, its not used, but gets pulled in via @nteract/renderers
+    externals: ['vscode', 'commonjs', 'ansi-to-react'],
     plugins: [
         new ForkTsCheckerWebpackPlugin({
             checkSyntacticErrors: true,

--- a/build/webpack/webpack.extension.config.js
+++ b/build/webpack/webpack.extension.config.js
@@ -20,7 +20,8 @@ module.exports = {
     },
     mode: 'production',
     devtool: 'source-map',
-    externals: ['vscode', 'commonjs'],
+    // Exclude ansi-to-react to avoid warnings about CG, its not used, but gets pulled in via @nteract/renderers
+    externals: ['vscode', 'commonjs', 'ansi-to-react'],
     plugins: [...common.getDefaultPlugins('extension')],
     resolve: {
         extensions: ['.ts', '.js']


### PR DESCRIPTION
Ensure we exclude ansi-to-react from output (ensure its not distributed) to address a CG issue
We cannot remove ansi-to-react component as its a dependency of @nteract/transform package that is used,
The next best is to just exclude from the output.