### PR TITLE
Add support for image/webp

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A [Visual Studio Code](https://code.visualstudio.com/) extension that provides r
     * image/png
     * image/jpeg
     * image/svg+xml
+    * image/webp
     * application/geo+json
     * application/vdom.v1+json
     * application/vnd.dataresource+json

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
                     "image/gif",
                     "image/png",
                     "image/jpeg",
+                    "image/webp",
                     "image/svg+xml",
                     "application/geo+json",
                     "application/vdom.v1+json",

--- a/src/client/render.tsx
+++ b/src/client/render.tsx
@@ -53,6 +53,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             case 'image/png':
             case 'image/gif':
             case 'image/jpeg':
+            case 'image/webp':
                 return this.renderImage(
                     this.props.mimeType,
                     data as unknown as Blob | MediaSource,


### PR DESCRIPTION
[webp](https://developers.google.com/speed/webp) is relatively new image format that is supported in VSCode again.

This very simple PR adds support for image/webp as mime type. 

I've manually tested that it works with VSCode using the lastest release tag: https://github.com/BlackHC/vscode-notebook-renderers/releases/tag/v1.0.17%2Bwebp

HEAD currently independently throws `Failed to resolve module specifier "ansi-to-react".` when I try to load the compiled extension in VSCode.